### PR TITLE
Add Content Endpoint

### DIFF
--- a/backend/API.md
+++ b/backend/API.md
@@ -1,0 +1,51 @@
+# API Specification
+### For DuoCode Server
+#### `/` - testing endpoint
+- Method: `GET`
+- returns placeholder text which is different depending on if the user is authenticated
+
+#### `/signup` - signup endpoint
+- Method: `POST`
+- Can handle url-encoded form data or JSON body data
+- Expects `name` and `password` fields in the request
+- Creates an entry in user database w/ username and hashed password
+- Response:
+  - 201 - Successful account creation
+  - 400 - If user already exists
+
+#### `/login` - login endpoint
+- Method: `POST`
+- Can handle url-encoded form data or JSON body data
+- Expects `name` and `password` fields in the request
+- Response:
+  - 300 - redirect to `/` endpoint, successful authentication
+  - 400 - bad information, no account exists
+
+#### `/logout` - logout endpoint
+- Method: `GET`
+- Tracks the user's session and logs out the session that sends this request
+- Response:
+  - 300 - redirect to `/` endpoint
+
+#### `/content/` - content endpoint
+- Method: `GET`
+- Serve question JSON content either through static URL path or through route parameters
+- Response:
+  - 200 - message sucess, body contains JSON
+  - 500 - some error ocurred, like requested resource doesn't exist or couldn't be read
+- Example requests:
+  - `GET /content/java/arrays/drag_drop/1/1`
+  - `GET /content/java/arrays/drag_drop/d1_1.json`
+- Both examples return the same result, which varies depending on type of question:
+```json
+{
+    "language": "java",
+    "subject": "arrays",
+    "type": "drag_drop",
+    "difficulty": 1,
+    "prompt": "Drag and drop the following blocks to create an empty int array of length 8 called myInts.",
+    "correct_ordering": ["int[]", "myInts", "=", "new", "int[8]", ";"]
+}
+```
+Note: the first way (route parameters) may be preferable since it is more
+flexible to changes in the way that question content is hosted.

--- a/backend/README.md
+++ b/backend/README.md
@@ -10,3 +10,4 @@ Helper scripts for building have been set up.
 - `npm run start` will start the server from the last build in `dist/`
 - `npm run build` will just run the Typescript compiler to build into `dist/`
 - `npm run clean` will remove the `dist/` directory
+- `npm run build` will make sure the backend builds, then will run the Jest test suite in `test/`.

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,6 +1,6 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   moduleDirectories: ['node_modules', 'src'],
   extensionsToTreatAsEsm: ['.ts'],
@@ -17,4 +17,5 @@ export default {
       },
     ],
   },
+  transformIgnorePatterns: [],
 };

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -15,6 +15,7 @@ export default {
       'ts-jest',
       {
         useESM: true,
+        isolatedModules: true, // this disables type checking
       },
     ],
   },

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 export default {
-  preset: 'ts-jest/presets/default-esm',
+  roots: ["<rootDir>/test"],
+  preset: 'ts-jest',
   testEnvironment: 'node',
   moduleDirectories: ['node_modules', 'src'],
   extensionsToTreatAsEsm: ['.ts'],

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "test": "jest",
-    "pretest": "npm run build",
+    "pretest": "npm run clean",
     "build": "npx tsc",
     "prestart": "npm run build",
     "start": "node dist/index.js",

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "test": "jest",
-    "pretest": "npm run clean",
+    "pretest": "npm run build",
     "build": "npx tsc",
     "prestart": "npm run build",
     "start": "node dist/index.js",

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -1,0 +1,21 @@
+export interface UserInfoDB {
+  insert_entry(info: UserInfo): UserInfo;
+  get_entry(user: string): UserInfo;
+}
+
+export interface UserInfo {
+  user: string,
+  pass_hash: string
+}
+
+export interface QuestionContentDB {
+  get_question(params: QuestionParams): Promise<JSON>;
+}
+
+export interface QuestionParams {
+  language: string,
+  subject: string,
+  type: string,
+  difficulty: string,
+  id: string,
+}

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -9,7 +9,7 @@ export interface UserInfo {
 }
 
 export interface QuestionContentDB {
-  get_question(params: QuestionParams): Promise<JSON>;
+  get_question(params: QuestionParams): Promise<Object>;
 }
 
 export interface QuestionParams {

--- a/backend/src/filecontentdb.ts
+++ b/backend/src/filecontentdb.ts
@@ -2,11 +2,16 @@ import { QuestionContentDB, QuestionParams } from "./db.js";
 import fs from "fs/promises";
 
 export class FileContentDB implements QuestionContentDB {
+  private static instance: FileContentDB;
+
   static get_db(): FileContentDB {
-    return new FileContentDB();
+    if (!FileContentDB.instance) {
+      FileContentDB.instance = new FileContentDB();
+    }
+    return FileContentDB.instance;
   }
 
-  async get_question(p: QuestionParams): Promise<JSON> {
+  async get_question(p: QuestionParams): Promise<Object> {
     let path = `../content/${p.language}/${p.subject}/${p.type}/d${p.difficulty}_${p.id}.json`;
     let data = await fs.readFile(path)
                  .then((res) => res.toString())

--- a/backend/src/filecontentdb.ts
+++ b/backend/src/filecontentdb.ts
@@ -1,0 +1,19 @@
+import { QuestionContentDB, QuestionParams } from "./db.js";
+import fs from "fs/promises";
+
+export class FileContentDB implements QuestionContentDB {
+  static get_db(): FileContentDB {
+    return new FileContentDB();
+  }
+
+  async get_question(p: QuestionParams): Promise<JSON> {
+    let path = `../content/${p.language}/${p.subject}/${p.type}/d${p.difficulty}_${p.id}.json`;
+    let data = await fs.readFile(path)
+                 .then((res) => res.toString())
+                 .catch((err) => {
+                    console.error("ERR: Failed to read file " + path + " with " + err);
+                    throw new Error("Failed to read from file " + err)
+                  });
+    return JSON.parse(data);
+  }
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -125,7 +125,7 @@ app.get('/logout', function (req, res, next) {
 });
 
 
-app.use(express.static("../content"));
+app.use("/content", express.static("../content"));
 
 
 // start listening on specified port

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,9 +1,11 @@
 import express from "express";
 import session from "express-session"; // TODO use a better session store
 import bcrypt from "bcrypt";
+import fs from "fs";
 
 import { MemDB } from "./memdb.js";
-import { UserInfoDB } from "./user_info_db.js";
+import { QuestionContentDB, UserInfoDB } from "./db.js";
+import { FileContentDB } from "./filecontentdb.js";
 
 
 // needed to make the express-session login examples work with TS, see https://akoskm.com/how-to-use-express-session-with-custom-sessiondata-typescript
@@ -21,6 +23,7 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 
 const db: UserInfoDB = MemDB.get_db();
+const content_db: QuestionContentDB = FileContentDB.get_db();
 
 
 // built in middleware - parses urlencoded and json request bodies into the req.body field
@@ -122,6 +125,18 @@ app.get('/logout', function (req, res, next) {
       res.redirect('/')
     })
   })
+});
+
+
+app.get("/content/:language/:subject/:type/:difficulty/:id", async (req, res) => {
+  console.log(req.params);
+
+  try {
+    let question_json = await content_db.get_question(req.params);
+    res.status(200).send(question_json);
+  } catch (error: any) {
+    res.status(500).send(error.message);
+  }
 });
 
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -135,7 +135,7 @@ app.get("/content/:language/:subject/:type/:difficulty/:id", async (req, res) =>
     let question_json = await content_db.get_question(req.params);
     res.status(200).send(question_json);
   } catch (error: any) {
-    res.status(500).send(error.message);
+    res.status(500).send(error.message); // TODO don't actually send the error message to user
   }
 });
 

--- a/backend/src/memdb.ts
+++ b/backend/src/memdb.ts
@@ -1,4 +1,4 @@
-import { UserInfo, UserInfoDB } from "./user_info_db.js";
+import { UserInfo, UserInfoDB } from "./db.js";
 
 // a quick in-memory database to test if the interface structure will work
 export class MemDB implements UserInfoDB {

--- a/backend/src/user_info_db.ts
+++ b/backend/src/user_info_db.ts
@@ -1,9 +1,0 @@
-export interface UserInfoDB {
-  insert_entry(info: UserInfo): UserInfo;
-  get_entry(user: string): UserInfo;
-}
-
-export interface UserInfo {
-  user: string,
-  pass_hash: string
-}

--- a/backend/test/filecontentdb.test.ts
+++ b/backend/test/filecontentdb.test.ts
@@ -1,0 +1,31 @@
+import { FileContentDB } from "../src/filecontentdb.js";
+
+test("file content DB is a singleton", () => {
+  let i1 = FileContentDB.get_db();
+  let i2 = FileContentDB.get_db();
+
+  expect(i1).toBe(i2);
+});
+
+test("content db reads the first drag+drop java arrays question", async () => {
+  let db = FileContentDB.get_db();
+
+  let q1 = await db.get_question({
+    language: "java",
+    subject: "arrays",
+    type: "drag_drop",
+    difficulty: "1",
+    id: "1"
+  });
+
+  let q2 = {
+    language: "java",
+    subject: "arrays",
+    type: "drag_drop",
+    difficulty: 1,
+    prompt: "Drag and drop the following blocks to create an empty int array of length 8 called myInts.",
+    correct_ordering: ["int[]", "myInts", "=", "new", "int[8]", ";"]
+  };
+
+  expect(q1).toEqual(q2);
+});

--- a/backend/test/memdb.test.ts
+++ b/backend/test/memdb.test.ts
@@ -5,7 +5,7 @@ test("mem DB is a singleton", () => {
   let i2 = MemDB.get_db();
 
   expect(i1).toBe(i2);
-  });
+});
 
 test("get values back after putting them in", () => {
   const input = { user: "foo", pass_hash: "bar" };

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
       "module": "NodeNext",
-      "moduleResolution": "NodeNext",
+      "moduleResolution": "nodenext",
       "target": "ES2020",
       "sourceMap": true,
       "outDir": "dist",
@@ -9,7 +9,8 @@
       "strict": true,
       "esModuleInterop": true,
       "incremental": true,
+      "types": ["@types/jest"],
     },
-    "include": ["src/**/*"],
+    "include": ["src/**/*", "test/**/*"],
     "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
Also look at `/backend/API.md` for a description of endpoints that the backend server supports. The content endpoint mirrors the file structure on the server, but it can be more flexible in case we don't want to host the content on the backend server anymore.

The test suite also started executing all the tests twice for some reason because it found both the JS and TS files. Testing config and scripts have been adjusted in the PR to change that.

I will note that currently the backend is also hosted on port 3000, which might be the same as the front end.