### PR TITLE
Track user progress on backend

### DIFF
--- a/backend/API.md
+++ b/backend/API.md
@@ -55,6 +55,7 @@ flexible to changes in the way that question content is hosted.
   - Retrieve a list with information about which lessons the user has completed
   - Response:
     - 200 - successfuly retrieval of completion information
+    - 401 - the user making the request is not authenticated
 - Method `POST`
   - Update the progress of the user by specifying a lesson which has been completed,
   adding that lesson to the list of lessons the user has completed.
@@ -63,3 +64,4 @@ flexible to changes in the way that question content is hosted.
   that subject
   - Response:
     - 200 - successfully added to list of completed lessons for the user
+    - 401 - if the user making the request is not authenticated

--- a/backend/API.md
+++ b/backend/API.md
@@ -27,7 +27,7 @@
 - Response:
   - 300 - redirect to `/` endpoint
 
-#### `/content/` - content endpoint
+#### `/content` - content endpoint
 - Method: `GET`
 - Serve question JSON content either through static URL path or through route parameters
 - Response:
@@ -49,3 +49,17 @@
 ```
 Note: the first way (route parameters) may be preferable since it is more
 flexible to changes in the way that question content is hosted.
+
+#### `/completion` - completion/progress endpoint
+- Method: `GET`
+  - Retrieve a list with information about which lessons the user has completed
+  - Response:
+    - 200 - successfuly retrieval of completion information
+- Method `POST`
+  - Update the progress of the user by specifying a lesson which has been completed,
+  adding that lesson to the list of lessons the user has completed.
+  - Expects a body with `language`, `subject` fields, and optionally a `level` field.
+  If there is no `level` field, it will be treated as the milestone completion for
+  that subject
+  - Response:
+    - 200 - successfully added to list of completed lessons for the user

--- a/backend/README.md
+++ b/backend/README.md
@@ -10,4 +10,4 @@ Helper scripts for building have been set up.
 - `npm run start` will start the server from the last build in `dist/`
 - `npm run build` will just run the Typescript compiler to build into `dist/`
 - `npm run clean` will remove the `dist/` directory
-- `npm run build` will make sure the backend builds, then will run the Jest test suite in `test/`.
+- `npm run test` will make sure the backend builds, then will run the Jest test suite in `test/`.

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -1,11 +1,13 @@
 export interface UserInfoDB {
   insert_entry(info: UserInfo): UserInfo;
   get_entry(user: string): UserInfo;
+  append_completion(user: string, completion: string): void;
 }
 
 export interface UserInfo {
   user: string,
-  pass_hash: string
+  pass_hash: string,
+  completed?: Array<string>, // optional
 }
 
 export interface QuestionContentDB {

--- a/backend/src/memdb.ts
+++ b/backend/src/memdb.ts
@@ -30,4 +30,10 @@ export class MemDB implements UserInfoDB {
   get_entry(user: string): UserInfo {
     return this.db[user];
   }
+
+  append_completion(user: string, completion: string): void {
+    // TODO if this question mark is anything like rust this can throw an error
+    // but it should be an invariant that every entry has an empty completed list
+    this.db[user].completed?.push(completion);
+  }
 }

--- a/backend/test/memdb.test.ts
+++ b/backend/test/memdb.test.ts
@@ -1,45 +1,71 @@
 import { MemDB } from "../src/memdb.js";
 
-test("mem DB is a singleton", () => {
-  let i1 = MemDB.get_db();
-  let i2 = MemDB.get_db();
+describe("MemDB in-memory database", () => {
+  it("is a singleton", () => {
+    let i1 = MemDB.get_db();
+    let i2 = MemDB.get_db();
 
-  expect(i1).toBe(i2);
-});
+    expect(i1).toBe(i2);
+  });
 
-test("get values back after putting them in", () => {
-  const input = { user: "foo", pass_hash: "bar" };
+  it("can get values back after putting them in", () => {
+    const input = { user: "foo", pass_hash: "bar" };
 
-  let db = MemDB.get_db();
+    let db = MemDB.get_db();
 
-  db.insert_entry(input);
-  let output = db.get_entry("foo");
-  expect(output).toEqual(input);
-});
+    db.insert_entry(input);
+    let output = db.get_entry("foo");
+    expect(output).toEqual(input);
+  });
 
-test("values don't change somehow", () => {
-  const input = { user: "foo", pass_hash: "bar" };
+  it("has values that don't change between gets", () => {
+    const input = { user: "foo", pass_hash: "bar" };
 
-  let db = MemDB.get_db();
+    let db = MemDB.get_db();
 
-  db.insert_entry(input);
-  let output1 = db.get_entry("foo");
-  let output2 = db.get_entry("foo");
-  let output3 = db.get_entry("foo");
-  expect(output1).toEqual(output2);
-  expect(output2).toEqual(output3);
-});
+    db.insert_entry(input);
+    let output1 = db.get_entry("foo");
+    let output2 = db.get_entry("foo");
+    let output3 = db.get_entry("foo");
+    expect(output1).toEqual(output2);
+    expect(output2).toEqual(output3);
+  });
 
-test("there can only be one of each key", () => {
-  const i1 = { user: "foo", pass_hash: "abc" };
-  const i2 = { user: "foo", pass_hash: "xyz" }
-  const db = MemDB.get_db();
+  it("has only one of each key", () => {
+    const i1 = { user: "foo", pass_hash: "abc" };
+    const i2 = { user: "foo", pass_hash: "xyz" }
+    const db = MemDB.get_db();
 
-  db.insert_entry(i1);
+    db.insert_entry(i1);
 
-  const output1 = db.insert_entry(i2);
-  const output2 = db.get_entry("foo");
+    const output1 = db.insert_entry(i2);
+    const output2 = db.get_entry("foo");
 
-  expect(output1).toEqual(i1);
-  expect(output2).toEqual(i2);
+    expect(output1).toEqual(i1);
+    expect(output2).toEqual(i2);
+  });
+
+  it("stores and retrieves a level completion list", () => {
+    const user = { user: "foo", pass_hash: "abc", completed: [] }
+    const db = MemDB.get_db();
+
+    db.insert_entry(user);
+
+    db.append_completion("foo", "java_arrays_1");
+    db.append_completion("foo", "java_arrays_2");
+
+    const output_completion = db.get_entry("foo").completed;
+
+    expect(output_completion).toBeTruthy();
+    expect(output_completion).toEqual(["java_arrays_1", "java_arrays_2"]);
+  });
+
+  it("can have an empty completion list", () => {
+    const user = { user: "foo", pass_hash: "abc", completed: [] }
+    const db = MemDB.get_db();
+    db.insert_entry(user);
+    const output_completion = db.get_entry("foo").completed;
+    expect(output_completion).toHaveLength(0);
+    expect(output_completion).toEqual([]);
+  });
 });


### PR DESCRIPTION
Defines a new `/completion` endpoint, which supports `GET` and `POST`. See `backend/API.md` for details.