### PR TITLE
Run Build via CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,8 @@
 .PHONY: install build run deploy test
 
 install:
-	cd ./frontend/ && npm install
-	cd ./frontend/ && npm install --save-dev
-	cd ./backend/ && npm install
-	cd ./backend/ && npm install --save-dev
+	cd ./frontend/ && npm ci
+	cd ./backend/ && npm ci
 
 build:
 	cd ./frontend/ && npm run build


### PR DESCRIPTION
This PR attempts to solve the issue in the web hosting service where the build fails due to not finding TypeScript. Changed to CI to be consistent with the GitHub CI pipeline. 