### PR TITLE
Remove hardcoded server url for frontend content requests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "type": "module",
   "private": true,
-  "homepage": "http://localhost:3001/app",
+  "homepage": "https://duocode.onrender.com/app",
   "dependencies": {
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",

--- a/frontend/src/pages/dnd.tsx
+++ b/frontend/src/pages/dnd.tsx
@@ -42,7 +42,7 @@ const DragDrop: React.FC<DragDropProps> = ({submitRef, unit, difficulty}) => {
 
     useEffect(() => {
         async function fetchData() {
-            const response = await fetch("http://localhost:3001/content/java/" + unit + "/drag_drop/" + difficulty + "/1")
+            const response = await fetch("/content/java/" + unit + "/drag_drop/" + difficulty + "/1")
             const data = await response.json();
             const shuffledOrdering = shuffleArray(data.correct_ordering);
             setDragDrop({...data, correct_ordering: shuffledOrdering});

--- a/frontend/src/pages/multiplechoice.tsx
+++ b/frontend/src/pages/multiplechoice.tsx
@@ -44,7 +44,7 @@ const MultipleChoice: React.FC<MultipleChoiceProps> = ({submitRef, unit, difficu
 
     useEffect(() => {
         async function fetchData() {
-            const response = await fetch("http://localhost:3001/content/java/" + unit + "/multiple_choice/" + difficulty + "/1")
+            const response = await fetch("/content/java/" + unit + "/multiple_choice/" + difficulty + "/1")
             const data = await response.json();
             console.log(data)
             setQuestion(data)

--- a/frontend/src/pages/shortanswer.tsx
+++ b/frontend/src/pages/shortanswer.tsx
@@ -31,7 +31,7 @@ const ShortAnswer: React.FC<ShortAnswerProps> = ({submitRef, unit, difficulty}) 
     const [shortAnswerData, setshortAnwswer] = useState<shortAnswerData>(emptyShortAnswerData);
     useEffect(() => {
         async function fetchData() {
-            const response = await fetch("http://localhost:3001/content/java/" + unit + "/short_response/" + difficulty + "/1")
+            const response = await fetch("/content/java/" + unit + "/short_response/" + difficulty + "/1")
             const data = await response.json();
             setshortAnwswer(data)
             console.log(data)


### PR DESCRIPTION
As long as frontend is served by backend, this should work to make the frontend send requests to wherever the backend is hosted.