### PR TITLE
Implemented back action handling for questions

### DIFF
--- a/frontend/src/pages/question.tsx
+++ b/frontend/src/pages/question.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState }from 'react';
+import React, {useEffect, useRef, useState }from 'react';
 import './question.css';
 
 import CloseBtn from '../components/CloseBtn'
@@ -110,10 +110,19 @@ const Question: React.FC<QuestionProps> = ({language, unitName, difficulty, onCo
     /**
      * Prevents user from accidently going back to menu without finishing the level.
      */
-    window.addEventListener('beforeunload', function (event) {
-        event.preventDefault();
-        event.returnValue = '';
-    });
+    useEffect(() => {
+        const handleBeforeUnload = (event: any) => {
+            event.preventDefault();
+            event.returnValue = '';
+        };
+
+        window.addEventListener('beforeunload', handleBeforeUnload);
+
+        return () => {
+            window.removeEventListener('beforeunload', handleBeforeUnload);
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     const handleCloseClick  = () => {
         const confirmDialog = window.confirm('Are you sure you want to exit the level? Your progress will not be saved.');

--- a/frontend/src/pages/question.tsx
+++ b/frontend/src/pages/question.tsx
@@ -107,10 +107,25 @@ const Question: React.FC<QuestionProps> = ({language, unitName, difficulty, onCo
         setIsCorrect(true);
     };
 
+    /**
+     * Prevents user from accidently going back to menu without finishing the level.
+     */
+    window.addEventListener('beforeunload', function (event) {
+        event.preventDefault();
+        event.returnValue = '';
+    });
+
+    const handleCloseClick  = () => {
+        const confirmDialog = window.confirm('Are you sure you want to exit the level? Your progress will not be saved.');
+        if (confirmDialog) {
+            handleComplete()
+        }
+    }
+
     return (
         <div className='page'>
             <div className='question-header'>
-                <button type="submit" className="question-close" onClick={handleComplete}>
+                <button type="submit" className="question-close" onClick={handleCloseClick}>
                     <CloseBtn/>
                 </button>
 


### PR DESCRIPTION
Back action handling has been implemented for the back button and close button. When the back button is hit a pop up appears warning the user that their changes may not be saved however it will still send them to the log in page. The text in the pop up is generic. When you hit the close button a pop up appears with unique text and when you confirm it sends you back to the menu page. 